### PR TITLE
fix: set the variable correctly

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -65,7 +65,7 @@ SwitchToDeepinWine()
             msg 1 "Need to install 'yay' or 'yaourt' first." >&2
             exit 1
         else
-            $PACKAGE_MANAGER="yaourt"
+            PACKAGE_MANAGER="yaourt"
         fi
     fi
     for p in ${DEEPIN_WINE_DEPENDS}; do


### PR DESCRIPTION
This PR sets the variable correctly. One does not add `$` at the beginning of a variable name to set it.

```
/opt/apps/com.qq.weixin.deepin/files/run.sh: line 68: yay=yaourt: command not found
```